### PR TITLE
docs: add architecture overview and operator documentation template

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,282 @@
+# Architecture
+
+This document provides an overview of the Kubedoop Data Platform architecture, including its internal framework, built-in Operators, component dependencies, design principles, and data flow patterns.
+
+## Platform Architecture Overview
+
+Kubedoop is a Kubernetes-native DataOps platform that manages 15+ big data components
+through a unified Operator framework. The platform uses Helm charts
+for Operator installation and lifecycle management, running entirely on top of Kubernetes.
+
+```mermaid
+graph TB
+    subgraph Users["User Layer"]
+        UI[Web UI / CLI]
+        Apps[Data Applications]
+    end
+
+    subgraph Platform["Kubedoop Platform"]
+        Helm[Helm Charts]
+        subgraph Operators["Product Operators"]
+            OP1[Spark Operator]
+            OP2[Hive Operator]
+            OP3[Trino Operator]
+            OP4[Kafka Operator]
+            OP5[HDFS Operator]
+            OP6[... 8 more]
+        end
+        subgraph BuiltIn["Built-in Operators"]
+            CO[Commons Operator]
+            LO[Listener Operator]
+            SO[Secret Operator]
+        end
+    end
+
+    subgraph K8s["Kubernetes Cluster"]
+        API[Kubernetes API Server]
+        PV[Persistent Volumes]
+        NET[Network Policies]
+    end
+
+    Users --> Platform
+    Helm --> Operators
+    Operators --> BuiltIn
+    Operators --> K8s
+    BuiltIn --> K8s
+```
+
+## operator-go Framework
+
+All Kubedoop Operators are built on top of the **operator-go** framework, an in-house library that provides a unified abstraction for managing stateful data infrastructure on Kubernetes.
+
+### Unified CRD Abstraction
+
+The operator-go framework introduces a consistent CRD model across all Operators:
+
+- **Cluster**: The top-level resource representing a full component deployment
+- **Roles**: Logical groupings of processes with the same responsibility (e.g., NameNode, DataNode)
+- **Role Groups**: Multiple instances of a role, allowing differentiated configurations for high availability, resource isolation, or workload separation
+
+```yaml
+apiVersion: {group}.kubedoop.dev/v1alpha1
+kind: {ClusterKind}
+metadata:
+  name: my-cluster
+spec:
+  roleA:
+    config:           # Role-level config
+      resources:
+        cpu: { min: "1" }
+    roleGroups:
+      group-1:        # Role group with default config
+        replicas: 3
+      group-2:        # Role group with overridden config
+        replicas: 2
+        config:
+          resources:
+            cpu: { min: "2" }
+```
+
+### Lifecycle Management
+
+The operator-go framework handles the full lifecycle of component deployments:
+
+| Phase | Description |
+|-------|-------------|
+| **Creation** | Deploys StatefulSets, Services, ConfigMaps, and Secrets based on CRD specs |
+| **Scaling** | Adjusts replica counts for role groups without disrupting existing pods |
+| **Upgrading** | Performs rolling upgrades across role groups with configurable maxUnavailable |
+| **Failure Recovery** | Automatically restarts failed pods and reconciles desired vs. actual state |
+| **Configuration Updates** | Applies config changes with graceful rolling restarts |
+
+> Source code: [operator-go on GitHub](https://github.com/zncdatadev/operator-go)
+
+## Built-in Operators
+
+Kubedoop includes three built-in Operators that provide cross-cutting functionality shared by all product Operators:
+
+```mermaid
+graph LR
+    subgraph ProductOps["Product Operators"]
+        PO1[Spark Operator]
+        PO2[Hive Operator]
+        PO3[Trino Operator]
+    end
+
+    subgraph BuiltInOps["Built-in Operators"]
+        CO["Commons Operator<br/>Environment variables<br/>JVM parameters<br/>Pod templates"]
+        LO["Listener Operator<br/>Service / Ingress<br/>TLS certificates<br/>Service discovery"]
+        SO["Secret Operator<br/>Password injection<br/>Certificate mounting<br/>Credential rotation"]
+    end
+
+    PO1 --> CO
+    PO1 --> LO
+    PO1 --> SO
+    PO2 --> CO
+    PO2 --> LO
+    PO2 --> SO
+    PO3 --> CO
+    PO3 --> LO
+    PO3 --> SO
+```
+
+### Commons Operator
+
+The Commons Operator manages shared configuration that applies across all product Operators:
+
+- **Environment variables**: Injects common environment variables into component pods
+- **JVM parameters**: Configures JVM heap size, GC settings, and other Java runtime options
+- **Pod templates**: Provides a base Pod template (annotations, labels, affinity) that product Operators extend
+
+### Listener Operator
+
+The Listener Operator provides automated service discovery and network configuration:
+
+- **Service / Ingress generation**: Automatically creates Kubernetes Services and Ingress resources based on listener definitions
+- **TLS certificate management**: Provisions and rotates TLS certificates for encrypted communication
+- **Service discovery**: Enables components to discover each other through DNS and built-in service resolution
+
+### Secret Operator
+
+The Secret Operator handles secure credential management:
+
+- **Password injection**: Automatically generates and injects passwords into component pods as environment variables or files
+- **Certificate mounting**: Mounts TLS certificates and keys into pods from centralized Secret resources
+- **Credential rotation**: Supports periodic rotation of credentials without manual intervention
+
+## Component Dependencies
+
+The following diagram shows the dependency relationships between Kubedoop product Operators:
+
+```mermaid
+graph TD
+    ZK["Zookeeper Operator"]
+
+    HDFS["HDFS Operator"]
+    DB["Database<br/>(External)"]
+
+    Hive["Hive Operator"]
+    Trino["Trino Operator"]
+    Spark["Spark Operator"]
+    Kafka["Kafka Operator"]
+    Superset["Superset Operator"]
+    Doris["Doris Operator"]
+    HBase["HBase Operator"]
+    Kyuubi["Kyuubi Operator"]
+    NiFi["NiFi Operator"]
+    Airflow["Airflow Operator"]
+    DS["DolphinScheduler Operator"]
+
+    HDFS --> ZK
+    Hive --> ZK
+    Hive --> HDFS
+    Hive --> DB
+    Trino --> ZK
+    Trino --> HDFS
+    Trino --> Hive
+    Spark --> HDFS
+    Spark --> Hive
+    Kafka --> ZK
+    Superset --> DB
+    Doris --> ZK
+    HBase --> ZK
+    HBase --> HDFS
+    Kyuubi --> HDFS
+    Kyuubi --> Hive
+    NiFi --> ZK
+    NiFi --> HDFS
+    Airflow --> DB
+    DS --> ZK
+    DS --> DB
+```
+
+| Operator | Dependencies |
+|----------|-------------|
+| Zookeeper | None (foundational service) |
+| HDFS | Zookeeper |
+| Hive | Zookeeper, HDFS, Database |
+| Trino | Zookeeper, HDFS, Hive |
+| Spark | HDFS, Hive |
+| Kafka | Zookeeper |
+| Superset | Database |
+| Doris | Zookeeper |
+| HBase | Zookeeper, HDFS |
+| Kyuubi | HDFS, Hive |
+| NiFi | Zookeeper, HDFS |
+| Airflow | Database |
+| DolphinScheduler | Zookeeper, Database |
+
+## Design Principles
+
+Kubedoop is built on the following core design principles:
+
+### Kubernetes Native
+
+All components are managed through Kubernetes Custom Resource Definitions (CRDs)
+and Operators. There are no custom orchestration layers — the platform relies entirely
+on the Kubernetes API for state management, scheduling, and self-healing.
+
+### Declarative Configuration
+
+Users describe the *desired state* of their data infrastructure through YAML manifests.
+The Operators continuously reconcile the actual state with the desired state,
+ensuring consistency without manual intervention.
+
+### Pluggable Storage
+
+Storage is abstracted through Kubernetes StorageClass, allowing users to choose the
+underlying storage backend (SSD, HDD, NFS, cloud storage) without changing their
+component configuration. This enables flexible deployment across different environments.
+
+### Unified Security Model
+
+All Operators share a consistent security model through the built-in Secret Operator
+and Listener Operator. TLS encryption, authentication, and credential management
+are handled uniformly across all components.
+
+### Observability
+
+Kubedoop provides built-in observability for all managed components:
+
+- **Logging**: Centralized log collection and management
+- **Metrics**: Exposed through Prometheus-compatible endpoints
+- **Alerting**: Integration with alerting systems for proactive monitoring
+
+## Data Flow Example
+
+The following sequence diagram illustrates the data flow when a user submits a SQL query through Trino to read data from Hive:
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Trino as Trino Coordinator
+    participant TrinoW as Trino Worker
+    participant Hive as Hive Metastore
+    participant HDFS as HDFS NameNode
+    participant HDFSd as HDFS DataNode
+
+    User->>Trino: Submit SQL query (SELECT * FROM hive_table)
+    Trino->>Hive: Fetch table metadata (schema, location, format)
+    Hive-->>Trino: Return table metadata
+
+    Trino->>HDFS: Request file blocks from NameNode
+    HDFS-->>Trino: Return block locations
+
+    Trino->>TrinoW: Split query into tasks and assign to workers
+
+    loop For each data block
+        TrinoW->>HDFSd: Read data blocks
+        HDFSd-->>TrinoW: Return data
+    end
+
+    TrinoW->>Trino: Return processed results
+    Trino-->>User: Return query results
+```
+
+This flow demonstrates how Kubedoop's component Operators work together:
+
+1. **Trino** receives the query and coordinates execution
+2. **Hive Metastore** provides table schema and data location metadata
+3. **HDFS NameNode** manages the file system namespace and block locations
+4. **HDFS DataNodes** serve the actual data blocks to Trino Workers
+5. **Trino Workers** process the data in parallel and return results

--- a/docs/operators/_template.md
+++ b/docs/operators/_template.md
@@ -1,0 +1,251 @@
+# {Operator Name}
+
+> {A one-line description of the component this Operator manages and its role in the data platform.}
+
+## Overview
+
+{Brief introduction: what this component is, what problems it solves, and typical use cases. 2-3 paragraphs.}
+
+{Paragraph 1: What is this component? Describe its core functionality and position in the data ecosystem.}
+
+{Paragraph 2: What problems does it solve? What pain points does it address for users?}
+
+{Paragraph 3: Typical use cases and scenarios where this component shines.}
+
+## Prerequisites
+
+- Kubernetes {version}+
+- kubectl {version}+
+- {Other dependencies — e.g., if this component depends on HDFS, list HDFS Operator here}
+- Helm v3+ installed — see [Quick Start](../quick-start/installation.md)
+
+## Quick Start
+
+### Install the Operator
+
+Install the built-in Operators first (required dependencies):
+
+```bash
+helm install commons-operator kubedoop/commons-operator -n operators --create-namespace
+helm install listener-operator kubedoop/listener-operator -n operators
+helm install secret-operator kubedoop/secret-operator -n operators
+```
+
+Then install the product Operator:
+
+```bash
+helm install {operator-name} kubedoop/{operator-name} -n operators
+```
+
+Verify that the Operator pod is running:
+
+```bash
+kubectl get pods -n operators -l app.kubernetes.io/name={operator-name}
+```
+
+### Create a Namespace
+
+```bash
+kubectl create ns {operator-name}
+```
+
+### Deploy {Component}
+
+Create a minimal {Component} cluster using the following CRD example:
+
+```yaml
+apiVersion: {group}.kubedoop.dev/v1alpha1
+kind: {ClusterKind}
+metadata:
+  name: {cluster-name}
+  namespace: {operator-name}
+  labels:
+    app.kubernetes.io/name: {cluster-name}
+    app.kubernetes.io/instance: {cluster-name}
+spec:
+  # {Key configuration: specify the version of the component}
+  # {Add role-specific configurations here}
+
+  {roleName}:
+    # {Describe the responsibility of this role}
+    roleGroups:
+      default:
+        replicas: 1
+        # {Role group-specific configuration overrides}
+```
+
+```bash
+kubectl apply -f - <<EOF
+apiVersion: {group}.kubedoop.dev/v1alpha1
+kind: {ClusterKind}
+metadata:
+  name: {cluster-name}
+  namespace: {operator-name}
+spec:
+  {roleName}:
+    roleGroups:
+      default:
+        replicas: 1
+EOF
+```
+
+### Verify the Deployment
+
+Check that all pods are running:
+
+```bash
+kubectl get pods -n {operator-name}
+```
+
+Expected output:
+
+```
+NAME                                   READY   STATUS    RESTARTS   AGE
+{pod-name}-0                           1/1     Running   0          2m
+```
+
+Check the cluster status:
+
+```bash
+kubectl get {clusterkind} -n {operator-name}
+```
+
+## Configuration
+
+### Roles and Role Groups
+
+{List the roles available in this Operator and describe each role's responsibility.}
+
+| Role | Description |
+|------|-------------|
+| {role-1} | {What this role does} |
+| {role-2} | {What this role does} |
+
+Each role can have multiple role groups with different configurations for high availability, resource isolation, or workload separation.
+
+> For more details, see [Roles and Role Groups](../core-concepts/common-configuration-mechanisms/roles-and-role-groups.md).
+
+### Configurations
+
+{List configurable parameters with descriptions.}
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| {param-1} | {Description of the parameter} | {default-value} |
+| {param-2} | {Description of the parameter} | {default-value} |
+
+Configuration can be set at the role level or overridden at the role group level.
+
+> For more details, see [Overrides](../core-concepts/common-configuration-mechanisms/overrides.md).
+
+### Listeners and Services
+
+{If this Operator integrates with the Listener Operator for service discovery, explain the configuration.}
+
+{Describe which listeners are available (e.g., internal, external) and how to configure them.}
+
+```yaml
+spec:
+  {roleName}:
+    config:
+      listeners:
+        {listener-name}:
+          type: {internal|external}
+          # {Additional listener configuration}
+```
+
+> For more details, see [Service Discovery](../core-concepts/connectivity/service-discovery.md).
+
+### Dependencies
+
+{List the dependencies this Operator has on other components and how to configure them.}
+
+| Dependency | Required | Description |
+|-----------|----------|-------------|
+| {dep-1} | Yes | {Why this dependency is needed} |
+| {dep-2} | No | {Optional dependency description} |
+
+## Advanced
+
+### Resource Management
+
+{Describe how to configure CPU, memory, and storage resources for this Operator's roles.}
+
+```yaml
+spec:
+  {roleName}:
+    config:
+      resources:
+        cpu:
+          min: "1"
+          max: "2"
+        memory:
+          limit: "4Gi"
+        storage:
+          {volume-name}:
+            capacity: 100Gi
+```
+
+> For more details, see [Resource Management](../core-concepts/resources/resource-manage.md).
+
+### Pod Placement
+
+{Describe how to control pod scheduling using affinity, tolerations, and node selectors.}
+
+> For more details, see [Pod Placement](../core-concepts/operations/pod-placement.md).
+
+### Authentication and Security
+
+{Describe security-related configuration such as TLS, Kerberos, or internal authentication.}
+
+> For more details, see [Authentication](../core-concepts/security/authentication.md).
+
+### Logging
+
+{Describe how to configure and access logs for this component.}
+
+> For more details, see [Logging](../core-concepts/observability/logging.md).
+
+## Troubleshooting
+
+{List common issues and their resolutions specific to this Operator.}
+
+### Common Issues
+
+1. **{Issue title}**
+   - **Symptom**: {What the user sees}
+   - **Cause**: {Why this happens}
+   - **Resolution**: {Steps to fix}
+
+2. **{Issue title}**
+   - **Symptom**: {What the user sees}
+   - **Cause**: {Why this happens}
+   - **Resolution**: {Steps to fix}
+
+> For common issues across all Operators, see [Troubleshooting](../troubleshooting).
+
+## Clean Up
+
+Delete the {Component} cluster:
+
+```bash
+kubectl delete {clusterkind} {cluster-name} -n {operator-name}
+```
+
+Delete the namespace:
+
+```bash
+kubectl delete ns {operator-name}
+```
+
+Uninstall the Operator via Helm:
+
+```bash
+helm uninstall {operator-name} -n operators
+```
+
+## Related Links
+
+- [{Component} Official Documentation]({upstream-url})
+- [Kubedoop Operator for {Component} on GitHub]({github-url})
+- [{Component} on GitHub]({component-github-url})

--- a/i18n/zh/docusaurus-plugin-content-docs/current/operators/_template.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/operators/_template.md
@@ -1,0 +1,251 @@
+# {Operator Name}
+
+> {A one-line description of the component this Operator manages and its role in the data platform.}
+
+## 概述
+
+{Brief introduction: what this component is, what problems it solves, and typical use cases. 2-3 paragraphs.}
+
+{Paragraph 1: What is this component? Describe its core functionality and position in the data ecosystem.}
+
+{Paragraph 2: What problems does it solve? What pain points does it address for users?}
+
+{Paragraph 3: Typical use cases and scenarios where this component shines.}
+
+## 前置条件
+
+- Kubernetes {version}+
+- kubectl {version}+
+- {Other dependencies — e.g., if this component depends on HDFS, list HDFS Operator here}
+- Helm v3+ installed — see [Quick Start](../quick-start/installation.md)
+
+## 快速开始
+
+### 安装 Operator
+
+Install the built-in Operators first (required dependencies):
+
+```bash
+helm install commons-operator kubedoop/commons-operator -n operators --create-namespace
+helm install listener-operator kubedoop/listener-operator -n operators
+helm install secret-operator kubedoop/secret-operator -n operators
+```
+
+然后安装产品 Operator：
+
+```bash
+helm install {operator-name} kubedoop/{operator-name} -n operators
+```
+
+Verify that the Operator pod is running:
+
+```bash
+kubectl get pods -n operators -l app.kubernetes.io/name={operator-name}
+```
+
+### 创建命名空间
+
+```bash
+kubectl create ns {operator-name}
+```
+
+### 部署 {Component}
+
+使用以下 CRD 示例创建一个最小化的 {Component} 集群：
+
+```yaml
+apiVersion: {group}.kubedoop.dev/v1alpha1
+kind: {ClusterKind}
+metadata:
+  name: {cluster-name}
+  namespace: {operator-name}
+  labels:
+    app.kubernetes.io/name: {cluster-name}
+    app.kubernetes.io/instance: {cluster-name}
+spec:
+  # {Key configuration: specify the version of the component}
+  # {Add role-specific configurations here}
+
+  {roleName}:
+    # {Describe the responsibility of this role}
+    roleGroups:
+      default:
+        replicas: 1
+        # {Role group-specific configuration overrides}
+```
+
+```bash
+kubectl apply -f - <<EOF
+apiVersion: {group}.kubedoop.dev/v1alpha1
+kind: {ClusterKind}
+metadata:
+  name: {cluster-name}
+  namespace: {operator-name}
+spec:
+  {roleName}:
+    roleGroups:
+      default:
+        replicas: 1
+EOF
+```
+
+### 验证部署
+
+检查所有 Pod 是否正常运行：
+
+```bash
+kubectl get pods -n {operator-name}
+```
+
+预期输出：
+
+```
+NAME                                   READY   STATUS    RESTARTS   AGE
+{pod-name}-0                           1/1     Running   0          2m
+```
+
+检查集群状态：
+
+```bash
+kubectl get {clusterkind} -n {operator-name}
+```
+
+## 配置
+
+### 角色和角色组
+
+{List the roles available in this Operator and describe each role's responsibility.}
+
+| 角色 | 描述 |
+|------|------|
+| {role-1} | {What this role does} |
+| {role-2} | {What this role does} |
+
+每个角色可以有多个角色组，通过不同的配置实现高可用、资源隔离或负载分离。
+
+> 更多详情请参阅 [角色与角色组](../core-concepts/common-configuration-mechanisms/roles-and-role-groups.md)。
+
+### 配置项
+
+{List configurable parameters with descriptions.}
+
+| 参数 | 描述 | 默认值 |
+|------|------|--------|
+| {param-1} | {Description of the parameter} | {default-value} |
+| {param-2} | {Description of the parameter} | {default-value} |
+
+配置可以在角色级别设置，也可以在角色组级别覆盖。
+
+> 更多详情请参阅 [配置覆盖](../core-concepts/common-configuration-mechanisms/overrides.md)。
+
+### 监听器和服务
+
+{If this Operator integrates with the Listener Operator for service discovery, explain the configuration.}
+
+{Describe which listeners are available (e.g., internal, external) and how to configure them.}
+
+```yaml
+spec:
+  {roleName}:
+    config:
+      listeners:
+        {listener-name}:
+          type: {internal|external}
+          # {Additional listener configuration}
+```
+
+> For more details, see [Service Discovery](../core-concepts/connectivity/service-discovery.md).
+
+### 依赖
+
+{List the dependencies this Operator has on other components and how to configure them.}
+
+| 依赖组件 | 是否必需 | 描述 |
+|----------|----------|------|
+| {dep-1} | Yes | {Why this dependency is needed} |
+| {dep-2} | No | {Optional dependency description} |
+
+## 进阶配置
+
+### 资源管理
+
+{Describe how to configure CPU, memory, and storage resources for this Operator's roles.}
+
+```yaml
+spec:
+  {roleName}:
+    config:
+      resources:
+        cpu:
+          min: "1"
+          max: "2"
+        memory:
+          limit: "4Gi"
+        storage:
+          {volume-name}:
+            capacity: 100Gi
+```
+
+> 更多详情请参阅 [资源管理](../core-concepts/resources/resource-manage.md)。
+
+### Pod 调度
+
+{Describe how to control pod scheduling using affinity, tolerations, and node selectors.}
+
+> 更多详情请参阅 [Pod 调度](../core-concepts/operations/pod-placement.md)。
+
+### 认证与安全
+
+{Describe security-related configuration such as TLS, Kerberos, or internal authentication.}
+
+> 更多详情请参阅 [认证](../core-concepts/security/authentication.md)。
+
+### 日志
+
+{Describe how to configure and access logs for this component.}
+
+> 更多详情请参阅 [日志](../core-concepts/observability/logging.md)。
+
+## 故障排查
+
+{List common issues and their resolutions specific to this Operator.}
+
+### 常见问题
+
+1. **{Issue title}**
+   - **现象**：{用户看到的情况}
+   - **原因**：{为什么会发生}
+   - **解决方案**：{修复步骤}
+
+2. **{Issue title}**
+   - **Symptom**: {What the user sees}
+   - **Cause**: {Why this happens}
+   - **Resolution**: {Steps to fix}
+
+> 所有 Operator 的通用问题请参阅 [故障排查](../troubleshooting)。
+
+## 清理
+
+删除 {Component} 集群：
+
+```bash
+kubectl delete {clusterkind} {cluster-name} -n {operator-name}
+```
+
+删除命名空间：
+
+```bash
+kubectl delete ns {operator-name}
+```
+
+Uninstall the Operator via Helm:
+
+```bash
+helm uninstall {operator-name} -n operators
+```
+
+## 相关链接
+
+- [{Component} Official Documentation]({upstream-url})
+- [Kubedoop Operator for {Component} on GitHub]({github-url})
+- [{Component} on GitHub]({component-github-url})

--- a/i18n/zh/docusaurus-plugin-content-docs/current/operators/_template.md
+++ b/i18n/zh/docusaurus-plugin-content-docs/current/operators/_template.md
@@ -1,29 +1,29 @@
 # {Operator Name}
 
-> {A one-line description of the component this Operator manages and its role in the data platform.}
+> {该 Operator 管理的组件的一句话描述及其在数据平台中的角色。}
 
 ## 概述
 
-{Brief introduction: what this component is, what problems it solves, and typical use cases. 2-3 paragraphs.}
+{简要介绍：该组件是什么，解决什么问题，典型用例。2-3 段。}
 
-{Paragraph 1: What is this component? Describe its core functionality and position in the data ecosystem.}
+{第一段：该组件是什么？描述其核心功能和在数据生态中的定位。}
 
-{Paragraph 2: What problems does it solve? What pain points does it address for users?}
+{第二段：解决什么问题？为用户解决了哪些痛点？}
 
-{Paragraph 3: Typical use cases and scenarios where this component shines.}
+{第三段：典型用例和适用场景。}
 
 ## 前置条件
 
 - Kubernetes {version}+
 - kubectl {version}+
-- {Other dependencies — e.g., if this component depends on HDFS, list HDFS Operator here}
-- Helm v3+ installed — see [Quick Start](../quick-start/installation.md)
+- {其他依赖 — 例如：如果该组件依赖 HDFS，在此列出 HDFS Operator}
+- Helm v3+ 已安装 — 参见 [快速开始](../quick-start/installation.md)
 
 ## 快速开始
 
 ### 安装 Operator
 
-Install the built-in Operators first (required dependencies):
+先安装内置 Operator（必需依赖）：
 
 ```bash
 helm install commons-operator kubedoop/commons-operator -n operators --create-namespace
@@ -37,7 +37,7 @@ helm install secret-operator kubedoop/secret-operator -n operators
 helm install {operator-name} kubedoop/{operator-name} -n operators
 ```
 
-Verify that the Operator pod is running:
+验证 Operator Pod 是否正常运行：
 
 ```bash
 kubectl get pods -n operators -l app.kubernetes.io/name={operator-name}
@@ -63,15 +63,15 @@ metadata:
     app.kubernetes.io/name: {cluster-name}
     app.kubernetes.io/instance: {cluster-name}
 spec:
-  # {Key configuration: specify the version of the component}
-  # {Add role-specific configurations here}
+  # {关键配置：指定组件版本}
+  # {在此添加角色相关配置}
 
   {roleName}:
-    # {Describe the responsibility of this role}
+    # {描述该角色的职责}
     roleGroups:
       default:
         replicas: 1
-        # {Role group-specific configuration overrides}
+        # {角色组级别的配置覆盖}
 ```
 
 ```bash
@@ -114,12 +114,12 @@ kubectl get {clusterkind} -n {operator-name}
 
 ### 角色和角色组
 
-{List the roles available in this Operator and describe each role's responsibility.}
+{列出此 Operator 中的可用角色并描述各角色的职责。}
 
 | 角色 | 描述 |
 |------|------|
-| {role-1} | {What this role does} |
-| {role-2} | {What this role does} |
+| {role-1} | {该角色的职责} |
+| {role-2} | {该角色的职责} |
 
 每个角色可以有多个角色组，通过不同的配置实现高可用、资源隔离或负载分离。
 
@@ -127,12 +127,12 @@ kubectl get {clusterkind} -n {operator-name}
 
 ### 配置项
 
-{List configurable parameters with descriptions.}
+{列出可配置的参数及说明。}
 
 | 参数 | 描述 | 默认值 |
 |------|------|--------|
-| {param-1} | {Description of the parameter} | {default-value} |
-| {param-2} | {Description of the parameter} | {default-value} |
+| {param-1} | {参数描述} | {默认值} |
+| {param-2} | {参数描述} | {默认值} |
 
 配置可以在角色级别设置，也可以在角色组级别覆盖。
 
@@ -140,9 +140,9 @@ kubectl get {clusterkind} -n {operator-name}
 
 ### 监听器和服务
 
-{If this Operator integrates with the Listener Operator for service discovery, explain the configuration.}
+{如果此 Operator 通过 Listener Operator 集成服务发现，请说明配置方式。}
 
-{Describe which listeners are available (e.g., internal, external) and how to configure them.}
+{描述可用的监听器（如 internal、external）及其配置方式。}
 
 ```yaml
 spec:
@@ -151,25 +151,25 @@ spec:
       listeners:
         {listener-name}:
           type: {internal|external}
-          # {Additional listener configuration}
+          # {额外的监听器配置}
 ```
 
-> For more details, see [Service Discovery](../core-concepts/connectivity/service-discovery.md).
+> 更多详情请参阅 [服务发现](../core-concepts/connectivity/service-discovery.md)。
 
 ### 依赖
 
-{List the dependencies this Operator has on other components and how to configure them.}
+{列出此 Operator 对其他组件的依赖及配置方式。}
 
 | 依赖组件 | 是否必需 | 描述 |
 |----------|----------|------|
-| {dep-1} | Yes | {Why this dependency is needed} |
-| {dep-2} | No | {Optional dependency description} |
+| {dep-1} | 是 | {为什么需要此依赖} |
+| {dep-2} | 否 | {可选依赖的描述} |
 
 ## 进阶配置
 
 ### 资源管理
 
-{Describe how to configure CPU, memory, and storage resources for this Operator's roles.}
+{描述如何为此 Operator 的角色配置 CPU、内存和存储资源。}
 
 ```yaml
 spec:
@@ -190,37 +190,37 @@ spec:
 
 ### Pod 调度
 
-{Describe how to control pod scheduling using affinity, tolerations, and node selectors.}
+{描述如何通过亲和性、容忍度和节点选择器控制 Pod 调度。}
 
 > 更多详情请参阅 [Pod 调度](../core-concepts/operations/pod-placement.md)。
 
 ### 认证与安全
 
-{Describe security-related configuration such as TLS, Kerberos, or internal authentication.}
+{描述安全相关配置，如 TLS、Kerberos 或内部认证。}
 
 > 更多详情请参阅 [认证](../core-concepts/security/authentication.md)。
 
 ### 日志
 
-{Describe how to configure and access logs for this component.}
+{描述如何配置和访问此组件的日志。}
 
 > 更多详情请参阅 [日志](../core-concepts/observability/logging.md)。
 
 ## 故障排查
 
-{List common issues and their resolutions specific to this Operator.}
+{列出此 Operator 的常见问题及解决方案。}
 
 ### 常见问题
 
-1. **{Issue title}**
+1. **{问题标题}**
    - **现象**：{用户看到的情况}
    - **原因**：{为什么会发生}
    - **解决方案**：{修复步骤}
 
-2. **{Issue title}**
-   - **Symptom**: {What the user sees}
-   - **Cause**: {Why this happens}
-   - **Resolution**: {Steps to fix}
+2. **{问题标题}**
+   - **现象**：{用户看到的情况}
+   - **原因**：{为什么会发生}
+   - **解决方案**：{修复步骤}
 
 > 所有 Operator 的通用问题请参阅 [故障排查](../troubleshooting)。
 
@@ -238,7 +238,7 @@ kubectl delete {clusterkind} {cluster-name} -n {operator-name}
 kubectl delete ns {operator-name}
 ```
 
-Uninstall the Operator via Helm:
+通过 Helm 卸载 Operator：
 
 ```bash
 helm uninstall {operator-name} -n operators
@@ -246,6 +246,6 @@ helm uninstall {operator-name} -n operators
 
 ## 相关链接
 
-- [{Component} Official Documentation]({upstream-url})
-- [Kubedoop Operator for {Component} on GitHub]({github-url})
-- [{Component} on GitHub]({component-github-url})
+- [{Component} 官方文档]({upstream-url})
+- [Kubedoop Operator for {Component} GitHub]({github-url})
+- [{Component} GitHub]({component-github-url})

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -21,6 +21,7 @@ const sidebars: SidebarsConfig = {
       label: 'Quick Start',
       items: [
         'introduction',
+        'architecture',
         'quick-start/installation',
       ],
     },


### PR DESCRIPTION
## Summary

- Add platform architecture overview document with Mermaid diagrams
- Add standardized Operator documentation template (Helm-based)
- Update sidebar navigation

## Changes

- `docs/architecture.md` (new) — Platform architecture, operator-go framework,
  built-in operators, component dependencies, design principles, data flow example
- `docs/operators/_template.md` (new) — Standardized template for Operator docs
  (Overview, Prerequisites, Quick Start, Configuration, Advanced, Troubleshooting)
- `sidebars.ts` — Added architecture link in Quick Start section

## Testing

- [x] `npm run build` passes for both en and zh-Hans locales
- [x] No lines exceeding 200 characters
- [x] No OLM references (uses Helm-based installation)